### PR TITLE
Defer /boss responses to avoid Discord interaction timeout

### DIFF
--- a/src/interactions/slash/boss.js
+++ b/src/interactions/slash/boss.js
@@ -122,6 +122,8 @@ async function execute(interaction) {
     });
   }
 
+  await interaction.deferReply();
+
   const bossName = getBossName(boss, locale) || '—';
   const level = boss.defaultLevel != null ? String(boss.defaultLevel) : '—';
   const region = getRegionName(boss.region, locale) || '—';
@@ -156,7 +158,7 @@ async function execute(interaction) {
     embed.setImage('attachment://boss-stats.png');
   }
 
-  return interaction.reply({
+  return interaction.editReply({
     embeds: [embed],
     files: statsAttachment ? [statsAttachment] : undefined,
   });


### PR DESCRIPTION
## Summary
- defer the /boss command reply before performing longer processing
- edit the deferred reply with the final embed and attachment to keep the interaction alive

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99582b10c832da086645f31a233df